### PR TITLE
Add buffering of audio into lib Fixes #6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 ndarray = "0.15.6"
-ort = "2.0.0-rc.4"
+ort = "=2.0.0-rc.4"
 
 [features]
 default = ["static-model"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ impl VadSession {
 
         let vad_segment_length = VAD_BUFFER_MS * self.config.sample_rate / 1000;
         let num_chunks = self.session_audio.len() / vad_segment_length;
-        let start_chunk = self.processed_samples;
+        let start_chunk = self.processed_samples / vad_segment_length;
 
         let mut transitions = vec![];
 


### PR DESCRIPTION
The VAD model will fail with a tensor dimension mismatch if too small audio is streamed into the model. This PR moves the current most common buffering implementation internal to the library as well as adding some tests to make sure the buffering works as expected.

While I was working/looking in some areas I also fixed their docs.