### PR TITLE
Add in End Silence tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
-## 0.1.0 [15 Aug 2024]
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 ### Added
-- Initial version
+- Initial version of inference and switching logic taken from internal Emotech
+code
+- Added in `end_silence_length` to track the raw end silences

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,9 +366,15 @@ mod tests {
         assert_eq!(session.processed_samples, silence.len());
     }
 
+    /// We only allow for 8khz and 16khz audio.
     #[test]
     fn reject_invalid_sample_rate() {
         let mut config = VadConfig::default();
+        config.sample_rate = 16000;
+        VadSession::new(config.clone()).unwrap();
+        config.sample_rate = 8000;
+        VadSession::new(config.clone()).unwrap();
+
         config.sample_rate += 1;
         assert!(VadSession::new(config.clone()).is_err());
         assert!(VadSession::new_from_path("models/silero_vad.onnx", config.clone()).is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ impl VadSession {
             state: VadState::Silence,
             session_audio: vec![],
             processed_samples: 0,
+            silent_samples: 0,
             speech_start: None,
             speech_end: None,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ impl VadSession {
     /// measure is a raw unprocessed look of how many segments since the last speech are below the
     /// negative speech threshold.
     pub fn end_silence_duration(&self) -> Duration {
-        Duration::from_millis(self.silent_samples / (self.config.sample_rate / 1000) as u64)
+        Duration::from_millis((self.silent_samples / (self.config.sample_rate / 1000)) as u64)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,8 +286,16 @@ impl VadSession {
     }
 
     /// Get how long the current speech is in samples.
-    pub fn current_speech_len(&self) -> usize {
+    pub fn current_speech_samples(&self) -> usize {
         self.get_current_speech().len()
+    }
+
+    /// Returns the duration of the current speech segment. It is possible for this and
+    /// `Self::current_silence_duration` to both report >0s at  the same time as this takes into
+    /// account the switching and padding parameters of the VAD whereas the silence measure ignores
+    /// them instead of just focusing on raw network output.
+    pub fn current_speech_duration(&self) -> Duration {
+        Duration::from_millis((self.current_speech_samples() / (self.config.sample_rate / 1000)) as u64)
     }
 
     /// Get the current length of the VAD session.
@@ -308,7 +316,7 @@ impl VadSession {
     /// speaking because of redemption frames or other parameters that slow down the speed it can
     /// switch at. But this measure is a raw unprocessed look of how many segments since the last
     /// speech are below the negative speech threshold.
-    pub fn end_silence_samples(&self) -> usize {
+    pub fn current_silence_samples(&self) -> usize {
         self.silent_samples
     }
 
@@ -316,7 +324,7 @@ impl VadSession {
     /// redemption frames or other parameters that slow down the speed it can switch at. But this
     /// measure is a raw unprocessed look of how many segments since the last speech are below the
     /// negative speech threshold.
-    pub fn end_silence_duration(&self) -> Duration {
+    pub fn current_silence_duration(&self) -> Duration {
         Duration::from_millis((self.silent_samples / (self.config.sample_rate / 1000)) as u64)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,9 @@ impl VadSession {
     /// account the switching and padding parameters of the VAD whereas the silence measure ignores
     /// them instead of just focusing on raw network output.
     pub fn current_speech_duration(&self) -> Duration {
-        Duration::from_millis((self.current_speech_samples() / (self.config.sample_rate / 1000)) as u64)
+        Duration::from_millis(
+            (self.current_speech_samples() / (self.config.sample_rate / 1000)) as u64,
+        )
     }
 
     /// Get the current length of the VAD session.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use ndarray::{Array1, Array2, Array3, ArrayBase, Ix1, Ix3, OwnedRepr};
 use ort::{GraphOptimizationLevel, Session};
 use std::ops::Range;
 use std::path::Path;
+use std::time::Duration;
 
 /// Parameters used to configure a vad session. These will determine the sensitivity and switching
 /// speed of detection.
@@ -303,12 +304,20 @@ impl VadSession {
         self.state = VadState::Silence;
     }
 
-    /// Returns the length of the end silence. The VAD may be showing this as speaking because of
+    /// Returns the length of the end silence in number of samples. The VAD may be showing this as
+    /// speaking because of redemption frames or other parameters that slow down the speed it can
+    /// switch at. But this measure is a raw unprocessed look of how many segments since the last
+    /// speech are below the negative speech threshold.
+    pub fn end_silence_samples(&self) -> usize {
+        self.silent_samples
+    }
+
+    /// Returns the duration of the end silence. The VAD may be showing this as speaking because of
     /// redemption frames or other parameters that slow down the speed it can switch at. But this
     /// measure is a raw unprocessed look of how many segments since the last speech are below the
     /// negative speech threshold.
-    pub fn end_silence_length(&self) -> usize {
-        self.silent_samples
+    pub fn end_silence_duration(&self) -> Duration {
+        Duration::from_millis(self.silent_samples / (self.config.sample_rate / 1000) as u64)
     }
 }
 


### PR DESCRIPTION
For applications where we can avoid reprocessing data if there's only been silence at the end when the audio finishes but the VAD hasn't changed status it can be useful to track the VAD at a lower-level than the API currently provided. For this use case I'm adding an end silence tracking that just keeps track of how many trailing samples have a `<negative_speech_threshold likelihood`.

I was thinking there might be a smarter approach inside the state update but this seemed easier tbh. Happy to bikeshed a bit on names and any docs I've added in :smile: 