### PR TITLE
Add some basic tracing to library + enable in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.86"
 ndarray = "0.16"
 ort = "=2.0.0-rc.6"
 serde = { version = "1.0.208", features = ["derive"], optional = true }
+tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 
 [features]
 default = ["static-model"]
@@ -22,3 +23,4 @@ approx = "0.5.1"
 hound = "3.5.1"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.125"
+tracing-test = { version = "0.2.5", features = ["no-env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use ort::{GraphOptimizationLevel, Session};
 use std::ops::Range;
 use std::path::Path;
 use std::time::Duration;
+use tracing::trace;
 
 /// Parameters used to configure a vad session. These will determine the sensitivity and switching
 /// speed of detection.
@@ -195,6 +196,13 @@ impl VadSession {
         } else {
             self.silent_samples = 0;
         }
+
+        trace!(
+            vad_likelihood = prob,
+            samples,
+            silent_samples = self.silent_samples,
+            "performed silero inference"
+        );
 
         let current_silence = self.current_silence_duration();
 

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -20,6 +20,7 @@ use silero::*;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use tracing_test::traced_test;
 
 #[derive(Default, Debug, PartialEq, Deserialize, Serialize)]
 struct Summary {
@@ -37,11 +38,13 @@ struct Report {
 }
 
 #[test]
+#[traced_test]
 fn chunk_50_default_params_16k() {
     run_snapshot_test(50, VadConfig::default(), "default");
 }
 
 #[test]
+#[traced_test]
 fn chunk_50_default_params_8k() {
     let mut config = VadConfig::default();
     config.sample_rate = 8000;
@@ -49,11 +52,13 @@ fn chunk_50_default_params_8k() {
 }
 
 #[test]
+#[traced_test]
 fn chunk_30_default_params_16k() {
     run_snapshot_test(30, VadConfig::default(), "default");
 }
 
 #[test]
+#[traced_test]
 fn chunk_30_default_params_8k() {
     let mut config = VadConfig::default();
     config.sample_rate = 8000;
@@ -61,11 +66,13 @@ fn chunk_30_default_params_8k() {
 }
 
 #[test]
+#[traced_test]
 fn chunk_20_default_params_16k() {
     run_snapshot_test(20, VadConfig::default(), "default");
 }
 
 #[test]
+#[traced_test]
 fn chunk_20_default_params_8k() {
     let mut config = VadConfig::default();
     config.sample_rate = 8000;


### PR DESCRIPTION
The motivation of this is that for issues where the VAD may play a part and we want to see a more finegrained view of when it's activating etc we have no way of doing that. This adds tracing so we can at least enable tracing output for the silero library and aid in diagnosing these issues.

I think a single log line might be enough, the user can log state changes and tracing the likelihood + silent samples and samples knowing the thresholds you can infer more information. But willing to add more if people think it's useful. I've also done this without the attribute stuff to try and remove the proc macro compile hit from this lib at least
