### PR TITLE
Work on a take api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = ["dep:serde"]
 [dependencies]
 anyhow = "1.0.86"
 ndarray = "0.16"
-ort = "=2.0.0-rc.8"
+ort = "=2.0.0-rc.9"
 rubato = { version = "0.16.0", optional = true}
 serde = { version = "1.0.208", features = ["derive"], optional = true }
 thiserror = "1.0.64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = ["dep:serde"]
 [dependencies]
 anyhow = "1.0.86"
 ndarray = "0.16"
-ort = "=2.0.0-rc.6"
+ort = "=2.0.0-rc.8"
 rubato = { version = "0.16.0", optional = true}
 serde = { version = "1.0.208", features = ["derive"], optional = true }
 thiserror = "1.0.64"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub use crate::audio_resampler::resample_pcm;
 pub use crate::errors::VadError;
 use anyhow::{bail, Context, Result};
 use ndarray::{Array1, Array2, Array3, ArrayBase, Ix1, Ix3, OwnedRepr};
-use ort::{GraphOptimizationLevel, Session};
+use ort::session::{builder::GraphOptimizationLevel, Session};
 use std::ops::Range;
 use std::path::Path;
 use std::time::Duration;
@@ -215,7 +215,7 @@ impl VadSession {
         Ok(transitions)
     }
 
-    pub fn forward(&mut self, input: Vec<f32>) -> Result<ort::Value> {
+    pub fn forward(&mut self, input: Vec<f32>) -> Result<ort::value::Value> {
         let samples = input.len();
         let audio_tensor = Array2::from_shape_vec((1, samples), input)?;
         let mut result = self.model.run(ort::inputs![


### PR DESCRIPTION
A potential approach for https://github.com/emotechlab/silero-rs/issues/31 this provides an API so users can do _a thing_

Take will take audio out of the session audio buffer and adjust the start time of the segments to match - this is mostly for compat/UX. The main focus of this is to allow someone to evacuate some audio and shorten existing segments in case they're accruing an ever larger vector of audio samples while someone is nattering on.

I also did some cleanup of the code mainly:

1. speech_end_ms was only set in one place and set to `None` at the end of the block
2. Move out duration -> index into separate methods and add a panicking and non-panicking version
3. Fix the bad asserts in `get_current_audio` where underflow could mess things up