### PR TITLE
Refactor to tidy up samples->duration calculation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,7 +745,7 @@ mod tests {
         let taken = session.take_until(until);
 
         let (start, end) = session.current_buffer_range();
-        assert_eq!(until, start);
+        assert_eq!(start, until);
         assert_eq!(end, session_end);
 
         assert!(session.current_speech_samples() < current_untaken.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,7 +745,7 @@ mod tests {
         let taken = session.take_until(until);
 
         let (start, end) = session.current_buffer_range();
-        assert_eq!(start, until);
+        assert_eq!(until, start);
         assert_eq!(end, session_end);
 
         assert!(session.current_speech_samples() < current_untaken.len());


### PR DESCRIPTION
While going through the code I noticed a repeated calculation being done so just made a small method to do it. This also standardises on if we calculate the milliseconds and make a duration from that or the seconds - and consistency is always the best approach.

I know it says 3 commits but two of them are already in master this is just rebase magic at work :sweat_smile: 