### PR TITLE
Trim start silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ code
 - Added new pub function `validate_input` for `VadSession` struct. `process` function will use it to make sure input is valid in debug mode.
 - Added a new method: `processed_duration`. A sample is considered as processed if it has been seen by Silero NN.
 - API to get current start/end time of session audio
+- Ability to trim the starting silence to keep buffer size down
 
 ### Fixed
 - Potential OOM when handling long autio.


### PR DESCRIPTION
This is part of my current work to let engines add in smarter non-partial handling. trimming the start of the buffer isn't good enough if there's silence at the start of the buffer so this PR adds in the ability to trim the starting silence.