### PR TITLE
Add tests for including unprocessed samples in get_current_speech

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,16 @@ impl VadSession {
     pub fn session_audio_samples(&self) -> usize {
         self.session_audio.len()
     }
+
+    #[doc(hidden)]
+    pub fn current_unprocessed_samples(&self) -> usize {
+        dbg!(
+            self.session_audio.len(),
+            self.deleted_samples,
+            self.processed_samples
+        );
+        self.session_audio.len() + self.deleted_samples - self.processed_samples
+    }
 }
 
 impl Default for VadConfig {

--- a/tests/consistency.rs
+++ b/tests/consistency.rs
@@ -39,6 +39,108 @@ fn compare_birds() {
     compare_audio(&audio);
 }
 
+#[test]
+#[traced_test]
+fn include_unprocessed_bird() {
+    let audio = Path::new("tests/audio/birds.wav");
+    for chunk_ms in [20, 30, 50] {
+        should_include_unprocessed_when_is_speaking(audio, chunk_ms);
+    }
+}
+
+#[test]
+#[traced_test]
+fn include_unprocessed_audio_1() {
+    let audio = Path::new("tests/audio/sample_1.wav");
+    for chunk_ms in [20, 30, 50] {
+        should_include_unprocessed_when_is_speaking(audio, chunk_ms);
+    }
+}
+
+#[test]
+#[traced_test]
+fn include_unprocessed_audio_2() {
+    let audio = Path::new("tests/audio/sample_2.wav");
+    for chunk_ms in [20, 30, 50] {
+        should_include_unprocessed_when_is_speaking(audio, chunk_ms);
+    }
+}
+
+#[test]
+#[traced_test]
+fn include_unprocessed_audio_3() {
+    let audio = Path::new("tests/audio/sample_3.wav");
+    for chunk_ms in [20, 30, 50] {
+        should_include_unprocessed_when_is_speaking(audio, chunk_ms);
+    }
+}
+
+#[test]
+#[traced_test]
+fn include_unprocessed_audio_4() {
+    let audio = Path::new("tests/audio/sample_4.wav");
+    for chunk_ms in [20, 30, 50] {
+        should_include_unprocessed_when_is_speaking(audio, chunk_ms);
+    }
+}
+
+/// When is_speaking is true, get_current_speech should return everything starting from
+/// speech start time until the very end, including the unprocessed samples.
+fn should_include_unprocessed_when_is_speaking(audio: &Path, chunk_ms: usize) {
+    let config = VadConfig::default();
+    let mut vad = VadSession::new(config).unwrap();
+
+    // Read audio samples.
+    let step = if config.sample_rate == 16000 {
+        1
+    } else {
+        2 // Other sample rates are invalid so we'll just work on less data
+    };
+    let samples: Vec<f32> = WavReader::open(audio)
+        .unwrap()
+        .into_samples()
+        .step_by(step)
+        .map(|x| {
+            let modified = x.unwrap_or(0i16) as f32 / (i16::MAX as f32);
+            modified.clamp(-1.0, 1.0)
+        })
+        .collect();
+
+    // Send each chunk to vad for inference.
+    let chunk_size = (config.sample_rate * chunk_ms) / 1000;
+    let num_chunks = samples.len() / chunk_size;
+    let mut last_speech_start_ms = 0;
+    for i in 0..num_chunks {
+        let start = i * chunk_size;
+        let end = if i < num_chunks - 1 {
+            start + chunk_size
+        } else {
+            samples.len()
+        };
+
+        let transitions = vad.process(&samples[start..end]).unwrap();
+        // Update last_speech_start_ms
+        for transition in transitions {
+            if let VadTransition::SpeechStart { timestamp_ms } = transition {
+                last_speech_start_ms = timestamp_ms;
+            }
+        }
+
+        // The actual test logic.
+        if vad.is_speaking() {
+            let current_speech = vad.get_current_speech();
+            let total_time_send_to_vad = sample_nums_to_ms(end, &config);
+            let current_speech_end_time =
+                last_speech_start_ms + sample_nums_to_ms(current_speech.len(), &config);
+            assert_eq!(total_time_send_to_vad, current_speech_end_time);
+        }
+    }
+}
+
+fn sample_nums_to_ms(sample_num: usize, config: &VadConfig) -> usize {
+    ((1000 * sample_num) as f32 / config.sample_rate as f32) as usize
+}
+
 fn compare_audio(audio: &Path) {
     let config = VadConfig::default();
 

--- a/tests/consistency.rs
+++ b/tests/consistency.rs
@@ -43,7 +43,12 @@ fn compare_birds() {
 #[traced_test]
 fn include_unprocessed_audio_1() {
     let audio = Path::new("tests/audio/sample_1.wav");
-    for chunk_ms in [20, 30, 50] {
+    // Use prime number as chunk duration so we are more confident that the code indeed works. We also test common
+    // practical choices: 20, 30, 50.
+    for chunk_ms in [
+        2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89,
+        97, 20, 30, 50,
+    ] {
         should_include_unprocessed_when_is_speaking(audio, chunk_ms);
     }
 }
@@ -52,7 +57,10 @@ fn include_unprocessed_audio_1() {
 #[traced_test]
 fn include_unprocessed_audio_2() {
     let audio = Path::new("tests/audio/sample_2.wav");
-    for chunk_ms in [20, 30, 50] {
+    for chunk_ms in [
+        2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89,
+        97, 20, 30, 50,
+    ] {
         should_include_unprocessed_when_is_speaking(audio, chunk_ms);
     }
 }
@@ -61,7 +69,10 @@ fn include_unprocessed_audio_2() {
 #[traced_test]
 fn include_unprocessed_audio_3() {
     let audio = Path::new("tests/audio/sample_3.wav");
-    for chunk_ms in [20, 30, 50] {
+    for chunk_ms in [
+        2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89,
+        97, 20, 30, 50,
+    ] {
         should_include_unprocessed_when_is_speaking(audio, chunk_ms);
     }
 }
@@ -78,6 +89,8 @@ fn include_unprocessed_audio_4() {
 /// When is_speaking is true, get_current_speech should return everything starting from
 /// speech start time until the very end, including the unprocessed samples.
 fn should_include_unprocessed_when_is_speaking(audio: &Path, chunk_ms: usize) {
+    let mut test_executed = false;
+
     let config = VadConfig::default();
     let mut vad = VadSession::new(config).unwrap();
 
@@ -119,6 +132,7 @@ fn should_include_unprocessed_when_is_speaking(audio: &Path, chunk_ms: usize) {
 
         // The actual test logic.
         if vad.is_speaking() {
+            test_executed = true;
             let current_speech = vad.get_current_speech();
             let total_time_send_to_vad = sample_nums_to_ms(end, &config);
             let current_speech_end_time =
@@ -126,6 +140,7 @@ fn should_include_unprocessed_when_is_speaking(audio: &Path, chunk_ms: usize) {
             assert_eq!(total_time_send_to_vad, current_speech_end_time);
         }
     }
+    assert!(test_executed);
 }
 
 #[inline]

--- a/tests/consistency.rs
+++ b/tests/consistency.rs
@@ -137,6 +137,7 @@ fn should_include_unprocessed_when_is_speaking(audio: &Path, chunk_ms: usize) {
     }
 }
 
+#[inline]
 fn sample_nums_to_ms(sample_num: usize, config: &VadConfig) -> usize {
     ((1000 * sample_num) as f32 / config.sample_rate as f32) as usize
 }

--- a/tests/consistency.rs
+++ b/tests/consistency.rs
@@ -41,15 +41,6 @@ fn compare_birds() {
 
 #[test]
 #[traced_test]
-fn include_unprocessed_bird() {
-    let audio = Path::new("tests/audio/birds.wav");
-    for chunk_ms in [20, 30, 50] {
-        should_include_unprocessed_when_is_speaking(audio, chunk_ms);
-    }
-}
-
-#[test]
-#[traced_test]
 fn include_unprocessed_audio_1() {
     let audio = Path::new("tests/audio/sample_1.wav");
     for chunk_ms in [20, 30, 50] {

--- a/tests/consistency.rs
+++ b/tests/consistency.rs
@@ -81,7 +81,10 @@ fn include_unprocessed_audio_3() {
 #[traced_test]
 fn include_unprocessed_audio_4() {
     let audio = Path::new("tests/audio/sample_4.wav");
-    for chunk_ms in [20, 30, 50] {
+    for chunk_ms in [
+        2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89,
+        97, 20, 30, 50,
+    ] {
         should_include_unprocessed_when_is_speaking(audio, chunk_ms);
     }
 }
@@ -138,6 +141,7 @@ fn should_include_unprocessed_when_is_speaking(audio: &Path, chunk_ms: usize) {
             let current_speech_end_time =
                 last_speech_start_ms + sample_nums_to_ms(current_speech.len(), &config);
             assert_eq!(total_time_send_to_vad, current_speech_end_time);
+            assert!(vad.current_unprocessed_samples() > 0);
         }
     }
     assert!(test_executed);


### PR DESCRIPTION
As title

General idea: if `get_current_speech` includes unprocessed samples, then the last speech start timestamp + duration of current_speech should be equal to the total duration we send to vad. 