### PR TITLE
Update ort to v2.0.0-rc.12 and ndarray to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ serde = ["dep:serde"]
 [dependencies]
 anyhow = "1.0.86"
 audioadapter-buffers = { version = "3.0.0", optional = true }
-ndarray = "0.16"
-ort = "=2.0.0-rc.10"
+ndarray = "0.17"
+ort = "=2.0.0-rc.12"
 rubato = { version = "2.0.0", optional = true}
 serde = { version = "1.0.208", features = ["derive"], optional = true }
 thiserror = "2.0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "audio_resampler")]
 pub use crate::audio_resampler::resample_pcm;
 pub use crate::errors::VadError;
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use ndarray::{Array1, Array2, Array3, ArrayBase, Ix1, Ix3, OwnedRepr};
 use ort::session::{builder::GraphOptimizationLevel, Session};
 use ort::value::TensorRef;
@@ -139,10 +139,14 @@ impl VadSession {
         if ![8000_usize, 16000].contains(&config.sample_rate) {
             bail!("Unsupported sample rate, use 8000 or 16000!");
         }
-        let model = Session::builder()?
-            .with_optimization_level(GraphOptimizationLevel::Level3)?
-            .with_intra_threads(4)?
-            .commit_from_memory(model_bytes)?;
+        let model = Session::builder()
+            .map_err(|e| anyhow!("{e}"))?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| anyhow!("{e}"))?
+            .with_intra_threads(4)
+            .map_err(|e| anyhow!("{e}"))?
+            .commit_from_memory(model_bytes)
+            .map_err(|e| anyhow!("{e}"))?;
         let h_tensor = Array3::<f32>::zeros((2, 1, 64));
         let c_tensor = Array3::<f32>::zeros((2, 1, 64));
         let sample_rate_tensor = Array1::from_vec(vec![config.sample_rate as i64]);
@@ -242,17 +246,18 @@ impl VadSession {
         let samples = input.len();
         let audio_tensor = Array2::from_shape_vec((1, samples), input)?;
         let mut result = self.model.run(ort::inputs![
-            TensorRef::from_array_view(audio_tensor.view())?,
-            TensorRef::from_array_view(self.sample_rate_tensor.view())?,
-            TensorRef::from_array_view(self.h_tensor.view())?,
-            TensorRef::from_array_view(self.c_tensor.view())?
-        ])?;
+            TensorRef::from_array_view(audio_tensor.view()).map_err(|e| anyhow!("{e}"))?,
+            TensorRef::from_array_view(self.sample_rate_tensor.view()).map_err(|e| anyhow!("{e}"))?,
+            TensorRef::from_array_view(self.h_tensor.view()).map_err(|e| anyhow!("{e}"))?,
+            TensorRef::from_array_view(self.c_tensor.view()).map_err(|e| anyhow!("{e}"))?
+        ]).map_err(|e| anyhow!("{e}"))?;
 
         // Update internal state tensors.
         self.h_tensor = result
             .get("hn")
             .unwrap()
-            .try_extract_array::<f32>()?
+            .try_extract_array::<f32>()
+            .map_err(|e| anyhow!("{e}"))?
             .to_owned()
             .into_shape_with_order((2, 1, 64))
             .context("Shape mismatch for h_tensor")?;
@@ -260,10 +265,11 @@ impl VadSession {
         self.c_tensor = result
             .get("cn")
             .unwrap()
-            .try_extract_array::<f32>()?
+            .try_extract_array::<f32>()
+            .map_err(|e| anyhow!("{e}"))?
             .to_owned()
             .into_shape_with_order((2, 1, 64))
-            .context("Shape mismatch for h_tensor")?;
+            .context("Shape mismatch for c_tensor")?;
 
         let prob_tensor = result.remove("output").unwrap();
         Ok(prob_tensor)
@@ -281,7 +287,7 @@ impl VadSession {
 
         let result = self.forward(audio_frame)?;
 
-        let prob = *result.try_extract_array::<f32>().unwrap().first().unwrap();
+        let prob = *result.try_extract_array::<f32>().map_err(|e| anyhow!("{e}")).unwrap().first().unwrap();
 
         let mut vad_change = None;
 


### PR DESCRIPTION
## Summary

- Bump `ort` from `=2.0.0-rc.10` to `=2.0.0-rc.12`
- Bump `ndarray` from `0.16` to `0.17` (required by ort rc.12)
- Map `ort::Error` to `anyhow::Error` explicitly in `new_from_bytes()` and `forward()`

## Motivation

`ort v2.0.0-rc.10` pins `smallvec = "=2.0.0-alpha.10"`, which creates dependency conflicts for downstream users when other crates in the dependency graph need a different `smallvec` version. `ort v2.0.0-rc.12` switched to `smallvec = "1.15"` (stable), resolving these conflicts.

There was already a dependabot PR (#59) to bump ort to rc.12, but it was reverted in #64 because `ndarray` wasn't updated simultaneously — ort rc.12 requires `ndarray 0.17`, and the type mismatch caused compile errors. This PR bumps both together.

## Breaking change in ort rc.12

`ort::Error<R>` in rc.12 includes a generic recovery value `R` that may not implement `Send + Sync`. This breaks the implicit `From<ort::Error> → anyhow::Error` conversion via the `?` operator. The fix is to explicitly map errors using `.map_err(|e| anyhow!("{e}"))`, which preserves the error message while discarding the non-Send recovery data.

## Testing

- `cargo check` passes with no errors
- No changes to test logic or public API