### PR TITLE
Set intra-thread concurrency to 1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ impl VadSession {
         }
         let model = Session::builder()?
             .with_optimization_level(GraphOptimizationLevel::Level3)?
-            .with_intra_threads(4)?
+            .with_intra_threads(1)?
             .commit_from_memory(model_bytes)?;
         let h_tensor = Array3::<f32>::zeros((2, 1, 64));
         let c_tensor = Array3::<f32>::zeros((2, 1, 64));


### PR DESCRIPTION
Main:

```
Timer precision: 10 ns
usage                      fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ process_file                          │               │               │               │         │
│  ├─ 20                   31.09 ms      │ 58.19 ms      │ 32.38 ms      │ 33.83 ms      │ 100     │ 100
│  ├─ 30                   31.5 ms       │ 35.82 ms      │ 32.31 ms      │ 32.59 ms      │ 100     │ 100
│  ├─ 50                   31.17 ms      │ 38.69 ms      │ 32.41 ms      │ 32.94 ms      │ 100     │ 100
│  ╰─ 100                  31.54 ms      │ 41.38 ms      │ 32.28 ms      │ 32.68 ms      │ 100     │ 100
├─ push_multiple_silences  12.68 ms      │ 15.62 ms      │ 13.17 ms      │ 13.3 ms       │ 100     │ 100
╰─ take                                  │               │               │               │         │
   ├─ 1                    44.1 ms       │ 61.76 ms      │ 46.32 ms      │ 46.85 ms      │ 100     │ 100
   ├─ 2                    44.38 ms      │ 58.62 ms      │ 47.74 ms      │ 47.77 ms      │ 100     │ 100
   ├─ 3                    44.59 ms      │ 77.11 ms      │ 46.91 ms      │ 47.56 ms      │ 100     │ 100
   ├─ 4                    43.78 ms      │ 57.74 ms      │ 46.25 ms      │ 47.11 ms      │ 100     │ 100
   ├─ 5                    43.39 ms      │ 49.01 ms      │ 46.18 ms      │ 46.44 ms      │ 100     │ 100
   ╰─ 6                    43.55 ms      │ 64.59 ms      │ 46.32 ms      │ 46.8 ms       │ 100     │ 100
   ```
   
   This PR
   
   ```
   Timer precision: 10 ns
usage                      fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ process_file                          │               │               │               │         │
│  ├─ 20                   31.89 ms      │ 46.76 ms      │ 32.46 ms      │ 33.49 ms      │ 100     │ 100
│  ├─ 30                   31.81 ms      │ 38.02 ms      │ 32.71 ms      │ 33.18 ms      │ 100     │ 100
│  ├─ 50                   31.93 ms      │ 40.92 ms      │ 33.27 ms      │ 34.31 ms      │ 100     │ 100
│  ╰─ 100                  32.31 ms      │ 44.85 ms      │ 34.13 ms      │ 34.9 ms       │ 100     │ 100
├─ push_multiple_silences  12.14 ms      │ 18.04 ms      │ 14.6 ms       │ 14.62 ms      │ 100     │ 100
╰─ take                                  │               │               │               │         │
   ├─ 1                    44.91 ms      │ 58 ms         │ 48.71 ms      │ 48.43 ms      │ 100     │ 100
   ├─ 2                    44.52 ms      │ 54.87 ms      │ 46.54 ms      │ 47.63 ms      │ 100     │ 100
   ├─ 3                    44.44 ms      │ 53.29 ms      │ 46.61 ms      │ 47.48 ms      │ 100     │ 100
   ├─ 4                    45.49 ms      │ 60.29 ms      │ 47.04 ms      │ 48.09 ms      │ 100     │ 100
   ├─ 5                    45.43 ms      │ 56.56 ms      │ 47.53 ms      │ 48.04 ms      │ 100     │ 100
   ╰─ 6                    44.95 ms      │ 55.38 ms      │ 47.06 ms      │ 48.07 ms      │ 100     │ 100
   ```
   
   I'd call that a statistically insignificant change.