### PR TITLE
Fixes some stuff in trim_start_silence

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,15 +389,13 @@ impl VadSession {
     /// remove all audio up-to the utterance start. If it is not speaking it will keep silence
     /// equal to the pre-speech padding frames at the end.
     pub fn trim_start_silence(&mut self) {
-        let last_index = if let Some(start_ms) = self.speech_start_ms {
-            self.duration_to_index(Duration::from_millis(start_ms as u64))
-        } else {
-            let remove_to = self
-                .session_time()
-                .saturating_sub(self.config.pre_speech_pad);
-            self.duration_to_index(remove_to)
+        let remove_to = match self.state {
+            VadState::Speech { start_ms, .. } => Duration::from_millis(start_ms as u64),
+            VadState::Silence => self
+                .processed_duration()
+                .saturating_sub(self.config.pre_speech_pad),
         };
-        if let Some(last_index) = last_index {
+        if let Some(last_index) = self.duration_to_index(remove_to) {
             self.session_audio.drain(..last_index);
             self.deleted_samples += last_index;
         }
@@ -920,27 +918,26 @@ mod tests {
         session.take_until(Duration::from_millis(1001));
     }
 
-    /// If we just have silence we don't want to remove the padding silence
+    /// Repeatedly trimming a silent stream keeps the buffer bounded while retaining pre-speech
+    /// padding and any audio that has not yet been processed.
     #[test]
     #[traced_test]
-    fn trim_start_silence_keep_padding() {
+    fn trim_start_silence_bounds_silent_buffer() {
         let config = VadConfig::default();
         let mut session = VadSession::new(config.clone()).unwrap();
         let silence = vec![0.0; 16000];
-        let mut added_samples = 0;
-        while session.samples_to_duration(session.session_audio.len()) < config.pre_speech_pad * 2 {
-            added_samples += silence.len();
+
+        for _ in 0..60 {
             session.process(&silence).unwrap();
+            session.trim_start_silence();
         }
 
-        session.trim_start_silence();
-
         let (start, end) = session.current_buffer_range();
-        assert!(end - start == config.pre_speech_pad);
-        assert!(session.session_audio.len() < added_samples);
+        assert!(end - start >= config.pre_speech_pad);
+        assert!(end - start < config.pre_speech_pad + Duration::from_millis(30));
         assert_eq!(
-            added_samples - session.deleted_samples,
-            session.session_audio.len()
+            silence.len() * 60,
+            session.deleted_samples + session.session_audio.len()
         );
     }
 

--- a/tests/consistency.rs
+++ b/tests/consistency.rs
@@ -54,6 +54,20 @@ fn compare_birds() {
     compare_audio(&audio);
 }
 
+/// Trimming silence after every streamed chunk must not change detected utterances.
+#[test]
+#[traced_test]
+fn trim_start_silence_preserves_segments() {
+    let audio = Path::new("tests/audio/sample_2.wav");
+    let config = VadConfig::default();
+    let chunks = ChunkStrategy::Fixed(100);
+
+    let untrimmed = silero_streaming(audio, chunks, config.clone());
+    let trimmed = silero_streaming_with_trimming(audio, chunks, config);
+
+    assert_eq!(untrimmed, trimmed);
+}
+
 fn compare_audio(audio: &Path) {
     let config = VadConfig::default();
 
@@ -110,10 +124,27 @@ fn silero_whole_file(audio: &Path, config: VadConfig) -> Vec<Segment> {
         .collect();
 
     let len = samples.len();
-    inner_vad_process(samples, ChunkStrategy::Fixed(len), config)
+    inner_vad_process(samples, ChunkStrategy::Fixed(len), config, false)
 }
 
 fn silero_streaming(audio: &Path, chunks: ChunkStrategy, config: VadConfig) -> Vec<Segment> {
+    silero_streaming_internal(audio, chunks, config, false)
+}
+
+fn silero_streaming_with_trimming(
+    audio: &Path,
+    chunks: ChunkStrategy,
+    config: VadConfig,
+) -> Vec<Segment> {
+    silero_streaming_internal(audio, chunks, config, true)
+}
+
+fn silero_streaming_internal(
+    audio: &Path,
+    chunks: ChunkStrategy,
+    config: VadConfig,
+    trim_start_silence: bool,
+) -> Vec<Segment> {
     let step = if config.sample_rate == 16000 {
         1
     } else {
@@ -129,10 +160,15 @@ fn silero_streaming(audio: &Path, chunks: ChunkStrategy, config: VadConfig) -> V
         })
         .collect();
 
-    inner_vad_process(samples, chunks, config)
+    inner_vad_process(samples, chunks, config, trim_start_silence)
 }
 
-fn inner_vad_process(samples: Vec<f32>, chunks: ChunkStrategy, config: VadConfig) -> Vec<Segment> {
+fn inner_vad_process(
+    samples: Vec<f32>,
+    chunks: ChunkStrategy,
+    config: VadConfig,
+    trim_start_silence: bool,
+) -> Vec<Segment> {
     let mut result = vec![];
     let mut session = VadSession::new(config.clone()).unwrap();
 
@@ -144,6 +180,9 @@ fn inner_vad_process(samples: Vec<f32>, chunks: ChunkStrategy, config: VadConfig
         end = samples.len().min(start + chunk_size);
 
         let mut transitions = session.process(&samples[start..end]).unwrap();
+        if trim_start_silence {
+            session.trim_start_silence();
+        }
         for transition in transitions.drain(..) {
             if let VadTransition::SpeechEnd {
                 start_timestamp_ms,


### PR DESCRIPTION
Respects short started but not ended speech buffers and adds a consistency test where if we keep calling trim_start_silence it won't change the utterance timestamps