### PR TITLE
Add ability to auto-trim start silence.

### DIFF
--- a/benches/usage.rs
+++ b/benches/usage.rs
@@ -1,5 +1,5 @@
 use hound::WavReader;
-use silero::VadSession;
+use silero::{VadConfig, VadSession};
 use std::time::Duration;
 
 fn main() {
@@ -8,9 +8,19 @@ fn main() {
 
 #[divan::bench(args = [20, 30, 50, 100])]
 fn process_file(chunk_ms: usize) {
+    process_file_with_config(chunk_ms, VadConfig::default());
+}
+
+#[divan::bench(args = [20, 30, 50, 100])]
+fn process_file_trim_start_audio(chunk_ms: usize) {
+    let config = VadConfig::default().with_trim_start_audio(true);
+    process_file_with_config(chunk_ms, config);
+}
+
+fn process_file_with_config(chunk_ms: usize, config: VadConfig) {
     let chunk_size = chunk_ms * 16; // 16000/1000
 
-    let mut session = VadSession::new(Default::default()).unwrap();
+    let mut session = VadSession::new(config).unwrap();
     let samples: Vec<f32> = WavReader::open("tests/audio/sample_2.wav")
         .unwrap()
         .into_samples()

--- a/examples/generate_json.rs
+++ b/examples/generate_json.rs
@@ -62,15 +62,13 @@ fn run_snapshot_test(_chunk_ms: usize, _args: Args) {
 
 #[cfg(feature = "serde")]
 fn run_snapshot_test(chunk_ms: usize, args: Args) {
-    let mut config = VadConfig {
-        positive_speech_threshold: args.positive_speech_threshold,
-        negative_speech_threshold: args.negative_speech_threshold,
-        pre_speech_pad: Duration::from_millis(args.pre_speech_pad_ms),
-        post_speech_pad: Duration::from_millis(args.post_speech_pad_ms),
-        redemption_time: Duration::from_millis(args.redemption_time_ms),
-        min_speech_time: Duration::from_millis(args.min_speech_time_ms),
-        ..Default::default()
-    };
+    let mut config = VadConfig::default()
+        .with_positive_speech_threshold(args.positive_speech_threshold)
+        .with_negative_speech_threshold(args.negative_speech_threshold)
+        .with_pre_speech_pad(Duration::from_millis(args.pre_speech_pad_ms))
+        .with_post_speech_pad(Duration::from_millis(args.post_speech_pad_ms))
+        .with_redemption_time(Duration::from_millis(args.redemption_time_ms))
+        .with_min_speech_time(Duration::from_millis(args.min_speech_time_ms));
 
     let mut summary = BTreeMap::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub struct VadConfig {
     pub redemption_time: Duration,
     pub sample_rate: usize,
     pub min_speech_time: Duration,
+    #[cfg_attr(feature = "serde", serde(default, skip))]
+    pub trim_start_audio: bool,
 }
 
 /// A VAD session create one of these for each audio stream you want to detect voice activity on
@@ -234,6 +236,9 @@ impl VadSession {
             if let Some(vad_ev) = vad_result {
                 transitions.push(vad_ev);
             }
+        }
+        if self.config.trim_start_audio {
+            self.trim_start_silence();
         }
         Ok(transitions)
     }
@@ -602,11 +607,52 @@ impl Default for VadConfig {
             redemption_time: Duration::from_millis(600),
             sample_rate: 16000,
             min_speech_time: Duration::from_millis(90),
+            trim_start_audio: false,
         }
     }
 }
 
 impl VadConfig {
+    pub fn with_positive_speech_threshold(mut self, threshold: f32) -> Self {
+        self.positive_speech_threshold = threshold;
+        self
+    }
+
+    pub fn with_negative_speech_threshold(mut self, threshold: f32) -> Self {
+        self.negative_speech_threshold = threshold;
+        self
+    }
+
+    pub fn with_pre_speech_pad(mut self, duration: Duration) -> Self {
+        self.pre_speech_pad = duration;
+        self
+    }
+
+    pub fn with_post_speech_pad(mut self, duration: Duration) -> Self {
+        self.post_speech_pad = duration;
+        self
+    }
+
+    pub fn with_redemption_time(mut self, duration: Duration) -> Self {
+        self.redemption_time = duration;
+        self
+    }
+
+    pub fn with_sample_rate(mut self, sample_rate: usize) -> Self {
+        self.sample_rate = sample_rate;
+        self
+    }
+
+    pub fn with_min_speech_time(mut self, duration: Duration) -> Self {
+        self.min_speech_time = duration;
+        self
+    }
+
+    pub fn with_trim_start_audio(mut self, enabled: bool) -> Self {
+        self.trim_start_audio = enabled;
+        self
+    }
+
     pub fn new(
         positive_speech_threshold: f32,
         negative_speech_threshold: f32,
@@ -615,6 +661,7 @@ impl VadConfig {
         redemption_time: Duration,
         sample_rate: usize,
         min_speech_time: Duration,
+        trim_start_audio: bool,
     ) -> Result<Self> {
         let config = VadConfig {
             positive_speech_threshold,
@@ -624,6 +671,7 @@ impl VadConfig {
             redemption_time,
             sample_rate,
             min_speech_time,
+            trim_start_audio,
         };
         match config.validate_config() {
             Ok(_) => Ok(config),
@@ -918,18 +966,17 @@ mod tests {
         session.take_until(Duration::from_millis(1001));
     }
 
-    /// Repeatedly trimming a silent stream keeps the buffer bounded while retaining pre-speech
-    /// padding and any audio that has not yet been processed.
+    /// Automatic trimming keeps a silent stream bounded while retaining pre-speech padding and any
+    /// audio that has not yet been processed.
     #[test]
     #[traced_test]
-    fn trim_start_silence_bounds_silent_buffer() {
-        let config = VadConfig::default();
+    fn automatic_trim_bounds_silent_buffer() {
+        let config = VadConfig::default().with_trim_start_audio(true);
         let mut session = VadSession::new(config.clone()).unwrap();
         let silence = vec![0.0; 16000];
 
         for _ in 0..60 {
             session.process(&silence).unwrap();
-            session.trim_start_silence();
         }
 
         let (start, end) = session.current_buffer_range();
@@ -939,6 +986,23 @@ mod tests {
             silence.len() * 60,
             session.deleted_samples + session.session_audio.len()
         );
+    }
+
+    /// Automatic trimming is opt-in so existing sessions retain their audio.
+    #[test]
+    #[traced_test]
+    fn automatic_trim_is_disabled_by_default() {
+        let config = VadConfig::default();
+        assert!(!config.trim_start_audio);
+
+        let mut session = VadSession::new(config).unwrap();
+        let silence = vec![0.0; 16000];
+        for _ in 0..3 {
+            session.process(&silence).unwrap();
+        }
+
+        assert_eq!(session.session_audio.len(), silence.len() * 3);
+        assert_eq!(session.deleted_samples, 0);
     }
 
     /// If we have speech in the current buffer then trimming silence shouldn't go beyond the start
@@ -1090,6 +1154,29 @@ mod tests {
         assert!(config.validate_config().is_err());
         assert!(config.validate_config_internal(false).is_err());
         assert!(config.validate_config_internal(true).is_err());
+    }
+
+    #[test]
+    fn fluent_config() {
+        let config = VadConfig::default()
+            .with_positive_speech_threshold(0.6)
+            .with_negative_speech_threshold(0.4)
+            .with_pre_speech_pad(Duration::from_millis(200))
+            .with_post_speech_pad(Duration::from_millis(100))
+            .with_redemption_time(Duration::from_millis(500))
+            .with_sample_rate(8000)
+            .with_min_speech_time(Duration::from_millis(120))
+            .with_trim_start_audio(true);
+
+        assert_eq!(config.positive_speech_threshold, 0.6);
+        assert_eq!(config.negative_speech_threshold, 0.4);
+        assert_eq!(config.pre_speech_pad, Duration::from_millis(200));
+        assert_eq!(config.post_speech_pad, Duration::from_millis(100));
+        assert_eq!(config.redemption_time, Duration::from_millis(500));
+        assert_eq!(config.sample_rate, 8000);
+        assert_eq!(config.min_speech_time, Duration::from_millis(120));
+        assert!(config.trim_start_audio);
+        config.validate_config().unwrap();
     }
 
     /// If we change a config during runtime we should see that change reflected in subsequence

--- a/tests/consistency.rs
+++ b/tests/consistency.rs
@@ -124,27 +124,10 @@ fn silero_whole_file(audio: &Path, config: VadConfig) -> Vec<Segment> {
         .collect();
 
     let len = samples.len();
-    inner_vad_process(samples, ChunkStrategy::Fixed(len), config, false)
+    inner_vad_process(samples, ChunkStrategy::Fixed(len), config)
 }
 
 fn silero_streaming(audio: &Path, chunks: ChunkStrategy, config: VadConfig) -> Vec<Segment> {
-    silero_streaming_internal(audio, chunks, config, false)
-}
-
-fn silero_streaming_with_trimming(
-    audio: &Path,
-    chunks: ChunkStrategy,
-    config: VadConfig,
-) -> Vec<Segment> {
-    silero_streaming_internal(audio, chunks, config, true)
-}
-
-fn silero_streaming_internal(
-    audio: &Path,
-    chunks: ChunkStrategy,
-    config: VadConfig,
-    trim_start_silence: bool,
-) -> Vec<Segment> {
     let step = if config.sample_rate == 16000 {
         1
     } else {
@@ -160,15 +143,18 @@ fn silero_streaming_internal(
         })
         .collect();
 
-    inner_vad_process(samples, chunks, config, trim_start_silence)
+    inner_vad_process(samples, chunks, config)
 }
 
-fn inner_vad_process(
-    samples: Vec<f32>,
+fn silero_streaming_with_trimming(
+    audio: &Path,
     chunks: ChunkStrategy,
     config: VadConfig,
-    trim_start_silence: bool,
 ) -> Vec<Segment> {
+    silero_streaming(audio, chunks, config.with_trim_start_audio(true))
+}
+
+fn inner_vad_process(samples: Vec<f32>, chunks: ChunkStrategy, config: VadConfig) -> Vec<Segment> {
     let mut result = vec![];
     let mut session = VadSession::new(config.clone()).unwrap();
 
@@ -180,9 +166,6 @@ fn inner_vad_process(
         end = samples.len().min(start + chunk_size);
 
         let mut transitions = session.process(&samples[start..end]).unwrap();
-        if trim_start_silence {
-            session.trim_start_silence();
-        }
         for transition in transitions.drain(..) {
             if let VadTransition::SpeechEnd {
                 start_timestamp_ms,


### PR DESCRIPTION
Does some refactoring and finally moves the config to a fluent builder.

Ran the benches there's no meaningful difference between trimming and not trimming on the benchmark audio